### PR TITLE
Update `BookType` to allow for lists (Task)

### DIFF
--- a/src/app/lib/booklist.ts
+++ b/src/app/lib/booklist.ts
@@ -6,6 +6,7 @@ export interface BookType {
   image: string;
   totalPages: number;
   pagesRead: number;
+  list: string;
 }
 
 // Defining the BookList type
@@ -21,7 +22,8 @@ export function instanceOfBook(object: any): object is BookType {
     object.author !== undefined &&
     object.image !== undefined &&
     object.totalPages !== undefined &&
-    object.pagesRead !== undefined
+    object.pagesRead !== undefined &&
+    object.list !== undefined
   ) {
     return true;
   } else {


### PR DESCRIPTION
Closes #10 

## PR Description

Updated the `BookType` to have a `list: string` field. This field can be used to tell the `List` that that `BookType` instance belongs to.