### PR TITLE
Add default book lists to default config

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -16,7 +16,8 @@ pub static DEFAULT_CONFIG: &'static str = indoc! {r#"
     "db_name": "",
     "db_url": "",
     "db_token": "",
-    "theme": "dark"
+    "theme": "dark",
+    "book_lists": ["In Progress", "Planned", "Aside", "Completed", "Dropped"]
 }
 "#};
 
@@ -43,6 +44,7 @@ pub struct Config {
     pub db_url: String,
     pub db_token: String,
     pub theme: String,
+    pub book_lists: Vec<String>,
 }
 
 impl Config {
@@ -78,6 +80,13 @@ impl Config {
             db_url: "".into(),
             db_token: "".into(),
             theme: "dark".into(),
+            book_lists: vec![
+                "In Progress".into(),
+                "Planned".into(),
+                "Aside".into(),
+                "Completed".into(),
+                "Dropped".into(),
+            ],
         }
     }
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -148,6 +148,7 @@ fn update_config(
     db_url: String,
     db_token: String,
     theme: String,
+    book_lists: Vec<String>,
 ) -> Result<String> {
     match config::write_config(Config {
         username,
@@ -155,6 +156,7 @@ fn update_config(
         db_url,
         db_token,
         theme,
+        book_lists,
     }) {
         Ok(_) => Ok(String::from("Wrote new config successfully!")),
         Err(e) => Err(Error { msg: e }),


### PR DESCRIPTION
Closes #11

Changes the default config to include 5 default book lists for users to use.

<!--
These HTML comments inside these brackets will not appear in the pull request (click Preview to see the final version).

The pull request should be linked to either:
 - a task (i.e., use 'Closes #TaskID' or 'Resolves #TaskID')
 - a bug (i.e., use 'Closes #BugID' or 'Fixes #BugID')

For more details, see: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
