### PR TITLE
Use serde serialize to format config into json. Fixes #18

### DIFF
--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -159,23 +159,10 @@ pub fn write_config(config: Config) -> Result<(), String> {
         config_file.push(CONFIG_DIR);
         config_file.push(CONFIG_FILE);
 
-        let formatted_config = indoc::formatdoc! {r#"
-{{
-    "username": "{username}",
-    "db_name": "{db_name}",
-    "db_url": "{db_url}",
-    "db_token": "{db_token}",
-    "theme": "{theme}"
-}}
-"#,
-        username = config.username,
-        db_name = config.db_name,
-        db_url = config.db_url,
-        db_token = config.db_token,
-        theme = config.theme
-        };
+        let serialized_string =
+            serde_json::to_string_pretty(&config).map_err(|e| format!("error serializing config: {e}"))?;
 
-        match fs::write(config_file, formatted_config) {
+        match fs::write(config_file, serialized_string) {
             Ok(_) => Ok(()),
             Err(e) => Err(e.to_string()),
         }


### PR DESCRIPTION
Closes #18

Instead of formatting into a template string, BookTrack now uses serde's serialize trait to convert the config struct into a JSON string.

<!--
These HTML comments inside these brackets will not appear in the pull request (click Preview to see the final version).

The pull request should be linked to either:
 - a task (i.e., use 'Closes #TaskID' or 'Resolves #TaskID')
 - a bug (i.e., use 'Closes #BugID' or 'Fixes #BugID')

For more details, see: https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->
